### PR TITLE
Update iframeheight.js

### DIFF
--- a/Src/iframeheight.js
+++ b/Src/iframeheight.js
@@ -229,7 +229,7 @@ Details: http://github.com/Sly777/Iframe-Height-Jquery-Plugin
                 if(base.$el.get(0).contentWindow.document.body !== null) {
                     base.debug.Log("This page has body info");
                     var _pageHeight = $(base.$el.get(0).contentWindow.document).height();
-                    var _pageName = base.$el.get(0).contentWindow.document.location.pathname.substring(window.location.pathname.lastIndexOf('/') + 1).toLowerCase();
+                    var _pageName = base.$el.get(0).contentWindow.document.location.pathname.substring(base.$el.get(0).contentWindow.document.location.pathname.lastIndexOf('/') + 1).toLowerCase();
 
                     base.debug.Log("page height : " + _pageHeight  + "px || page name : " + _pageName);
                     if((_pageHeight <= base.options.minimumHeight && base.options.exceptPages.indexOf(_pageName) == -1)) {


### PR DESCRIPTION
There is surely something wrong with this line. Also the fact that you are forced to have a file name on the end of the URL unnecessarily restrictive. If no name can be resolved for the window is not resize there for its imperative that the expression is able to resolve some name even if its not perfectly formed. I hope you can see what I mean.
