### PR TITLE
Fix setTimeout call when jQuery is in noConflict mode.

### DIFF
--- a/Src/iframeheight.js
+++ b/Src/iframeheight.js
@@ -177,7 +177,7 @@ Details: http://github.com/Sly777/Iframe-Height-Jquery-Plugin
         var tryFixIframe = function(){
             if($.iframeHeight.resizeCount <= base.options.resizeMaxTry){
                 $.iframeHeight.resizeCount++;
-                $.iframeHeight.resizeTimeout = setTimeout("$.iframeHeight.resizeIframe()", base.options.resizeWaitTime);
+                $.iframeHeight.resizeTimeout = setTimeout($.iframeHeight.resizeIframe, base.options.resizeWaitTime);
                 base.debug.Log($.iframeHeight.resizeCount + " time(s) tried");
             } else {
                 clearTimeout($.iframeHeight.resizeTimeout);


### PR DESCRIPTION
In `tryFixIframe`, `resizeIframe` was called with:

``` javascript
    $.iframeHeight.resizeTimeout = setTimeout("$.iframeHeight.resizeIframe()", base.options.resizeWaitTime);
```

This would throw a "TypeError: $ is undefined" if jQuery was being used in noConflict mode, because the string would be evaluated in the global context (see [MDN's documentation](https://developer.mozilla.org/en-US/docs/Web/API/window.setTimeout?redirectlocale=en-US&redirectslug=DOM%2Fwindow.setTimeout#Passing_string_literals)). Calling `resizeIframe` by using its direct reference fixes this error.

Here is my setup to reproduce this bug (jquery no conflict + cross-origin iframe):

![noconflict-tryfixiframe-bug](https://f.cloud.github.com/assets/877585/1277633/1014b494-2ed4-11e3-98a3-34993a1f56dc.PNG)

Here is [a gist with both files](https://gist.github.com/ThibWeb/6859797). NB: To easily reproduce the bug, I removed the secund part of this test: `if ((_pageHeight <= base.options.minimumHeight && base.options.exceptPages.indexOf(_pageName) == -1))`.
